### PR TITLE
mofidy:detail view 수정

### DIFF
--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -5,8 +5,8 @@ import { api } from "../../api/api";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
+  const [isSelected, setIsSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
-  const [isTodoChecked, setIsTodoChecked] = useState(false);
 
   const navigate = useNavigate();
 
@@ -20,13 +20,16 @@ const List = () => {
     navigate("signin");
   };
 
+  const displayDetail = () => {
+    setIsSelected(true);
+  };
+  const hiddenDetail = () => {
+    setIsSelected(false);
+  };
+
   const whichISelected = (e, selectedId) => {
     const selectedTodo = todoList.find(({ id }) => id === selectedId);
     setSelectedTodo(selectedTodo);
-  };
-
-  const selectOrNot = (e) => {
-    setIsTodoChecked(e.target.checked);
   };
 
   useEffect(() => {
@@ -51,7 +54,6 @@ const List = () => {
     //   },
     // });
   }, []);
-
   return (
     <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
@@ -65,17 +67,29 @@ const List = () => {
           +
         </button>
       </div>
-      {todoList.map(({ id, title }) => (
-        <Todo
-          key={id}
-          title={title}
-          id={id}
-          text={"Bernard Shelton"}
-          whichISelected={whichISelected}
-          selectOrNot={selectOrNot}
-        />
-      ))}
-      {isTodoChecked && <div className="bg-emerald-100 mx-5">{selectedTodo.content}</div>}
+      {todoList &&
+        todoList.map(({ id, title }) => (
+          <Todo
+            key={id}
+            title={title}
+            id={id}
+            whichISelected={whichISelected}
+            displayDetail={displayDetail}
+          />
+        ))}
+      {isSelected && (
+        <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
+          <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
+            {selectedTodo.content}
+          </p>
+          <button
+            onClick={hiddenDetail}
+            className="w-1/6 h-10 ml-5 bg-zinc-100  active:bg-zinc-300 active:text-white rounded-lg text-sm"
+          >
+            닫기
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,22 +1,33 @@
 import React from "react";
 import { CiEdit, CiSquareRemove } from "react-icons/ci";
 
-const Todo = ({ title, id, whichISelected, selectOrNot }) => {
+const Todo = ({ title, id, whichISelected, displayDetail }) => {
+  const makeCollapsedTitle = (index) => {
+    if (title.length < index) return title;
+
+    const startIndex = title.substring(0, index);
+    const concatedString = "...";
+    const collapsedTitle = startIndex + concatedString;
+    return collapsedTitle;
+  };
+
   return (
     <div
       onClick={(e) => {
         whichISelected(e, id);
       }}
-      className="flex items-center justify-center h-10 mb-5 group"
+      className="flex items-center justify-between h-10 mb-5 group"
     >
-      <label htmlFor={id} className="w-full h-10 ml-5">
-        <div className="flex items-center h-10 py-5 border-2 border-emerald-200 duration-150 active:scale-105 ">
-          <input id={id} type="checkbox" className="mx-5" onChange={selectOrNot} />
-          <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
-            {title}
-          </p>
-        </div>
-      </label>
+      <div
+        onClick={displayDetail}
+        className="flex items-center w-full h-10 ml-5 py-5 border-2 rounded-lg border-emerald-200 active:bg-emerald-100"
+      >
+        <input type="checkbox" className="mx-5" />
+        <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
+          {makeCollapsedTitle(20)}
+        </p>
+      </div>
+
       <div className=" flex items-center justify-center invisible group-hover:visible">
         <CiEdit className="duration-150 hover:scale-125 text-green-700 mr-3 " size="30px" />
         <CiSquareRemove className="duration-150 mr-5 hover:scale-125 text-red-700" size="30px" />


### PR DESCRIPTION


## 개발한 화면
https://user-images.githubusercontent.com/79638133/231313304-45143874-8e5c-4516-8e50-76b4ea67d556.mov



## 개발 내용

- label태그 삭제
- 체크박스에 체크 되야 detail이 보이던 방식에서 todo 클릭 하면 보이는것으로 수정
- detail 닫기 버튼 추가
- title의길이가 특정 index이상 되면 ... 으로 collapse되게 view 수정
- input scale transition 삭제

## 회고
- detail 을 어떤 조건에 보이게하고 안보이게 할지 방법을 선택하기 어려웠다.

