### PR TITLE
Feature/list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
   </body>
 </html>

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,10 +2,10 @@ const BASE = "http://localhost:8080";
 
 export const api = {
   getTodos: `${BASE}/todos`,
-  getTodoById: `${BASE}/todos/:id`,
+  getTodoById: `${BASE}/todos/`,
   createTodo: `${BASE}/todos`,
-  updateTodo: `${BASE}/todos/:id`,
-  deleteTodo: `${BASE}/todos:id`,
+  updateTodo: `${BASE}/todos/`,
+  deleteTodo: `${BASE}/todos/`,
   signIn: `${BASE}/users/login`,
   signUp: `${BASE}/users/create`,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,4 @@ import Router from "./Router";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(
-  <React.StrictMode>
-    <Router />
-  </React.StrictMode>
-);
+root.render(<Router />);

--- a/src/pages/Auth/Auth.jsx
+++ b/src/pages/Auth/Auth.jsx
@@ -23,7 +23,7 @@ const Auth = () => {
       body: JSON.stringify(userInfo),
     });
     const createdUser = await response.json();
-    console.log(createdUser.message);
+    alert(createdUser.message);
   };
 
   return (

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Todo from "./Todo";
 import { api } from "../../api/api";
+import TodoModal from "./TodoModal/TodoModal";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
   const [isSelected, setIsSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
+  const [isOpend, setIsOpend] = useState(false);
 
   const navigate = useNavigate();
 
@@ -32,6 +34,10 @@ const List = () => {
     setSelectedTodo(selectedTodo);
   };
 
+  const toggleTodoModal = () => {
+    setIsOpend((prev) => !prev);
+  };
+
   useEffect(() => {
     if (!localStorage.getItem("todo-token")) {
       alert("로그인이 필요합니다");
@@ -44,18 +50,9 @@ const List = () => {
         Authorization: localStorage.getItem("todo-token"),
       },
     });
-    getTodo("/mock/getTodo.json");
-    //TODO: createTodo 만들어지면 사용 예정
-    // getTodo(api.getTodos, {
-    //   method: "GET",
-    //   headers: {
-    //     "Content-type": "application/json;charset=utf-8",
-    //     Authorization: localStorage.getItem("todo-token"),
-    //   },
-    // });
-  }, []);
+  }, [todoList]);
   return (
-    <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
+    <div className="relative m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
         <button
           onClick={goToSignIn}
@@ -63,10 +60,14 @@ const List = () => {
         >
           Login
         </button>
-        <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white">
+        <button
+          onClick={toggleTodoModal}
+          className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white"
+        >
           +
         </button>
       </div>
+      {isOpend && <TodoModal setIsOpend={setIsOpend} />}
       {todoList &&
         todoList.map(({ id, title }) => (
           <Todo
@@ -80,7 +81,7 @@ const List = () => {
       {isSelected && (
         <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
           <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
-            {selectedTodo.content}
+            {selectedTodo.content || "todoDetail입니다"}
           </p>
           <button
             onClick={hiddenDetail}

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -6,10 +6,9 @@ import TodoModal from "./TodoModal/TodoModal";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
-  const [isSelected, setIsSelected] = useState(false);
+  const [isTodoSelected, setIsTodoSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
-  const [isOpend, setIsOpend] = useState(false);
-
+  const [isTodoModalOpend, setTodoModalIsOpend] = useState(false);
   const navigate = useNavigate();
 
   const getTodo = async (url, option) => {
@@ -23,10 +22,10 @@ const List = () => {
   };
 
   const displayDetail = () => {
-    setIsSelected(true);
+    setIsTodoSelected(true);
   };
   const hiddenDetail = () => {
-    setIsSelected(false);
+    setIsTodoSelected(false);
   };
 
   const whichISelected = (e, selectedId) => {
@@ -35,7 +34,21 @@ const List = () => {
   };
 
   const toggleTodoModal = () => {
-    setIsOpend((prev) => !prev);
+    setTodoModalIsOpend((prev) => !prev);
+  };
+
+  const deleteTodo = async (e, selectedId) => {
+    const response = await fetch(`${api.deleteTodo}${selectedId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-type": "application/json",
+        Authorization: localStorage.getItem("todo-token"),
+      },
+    });
+    if (response.ok) {
+      const filteredList = todoList.filter((list) => list.id !== selectedId);
+      setTodoList(filteredList);
+    }
   };
 
   useEffect(() => {
@@ -50,7 +63,12 @@ const List = () => {
         Authorization: localStorage.getItem("todo-token"),
       },
     });
+  }, []);
+
+  useEffect(() => {
+    if (todoList.length === 0) setIsTodoSelected(false);
   }, [todoList]);
+
   return (
     <div className="relative m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
@@ -67,7 +85,9 @@ const List = () => {
           +
         </button>
       </div>
-      {isOpend && <TodoModal setIsOpend={setIsOpend} />}
+      {isTodoModalOpend && (
+        <TodoModal setTodoModalIsOpend={setTodoModalIsOpend} setTodoList={setTodoList} />
+      )}
       {todoList &&
         todoList.map(({ id, title }) => (
           <Todo
@@ -76,9 +96,10 @@ const List = () => {
             id={id}
             whichISelected={whichISelected}
             displayDetail={displayDetail}
+            deleteTodo={deleteTodo}
           />
         ))}
-      {isSelected && (
+      {isTodoSelected && (
         <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
           <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
             {selectedTodo.content || "todoDetail입니다"}

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { CiEdit, CiSquareRemove } from "react-icons/ci";
 
-const Todo = ({ title, id, whichISelected, displayDetail }) => {
+const Todo = ({ title, id, whichISelected, displayDetail, deleteTodo }) => {
+  const [isEdit, setIsEdit] = useState(false);
+
   const makeCollapsedTitle = (index) => {
     if (title.length < index) return title;
 
@@ -11,13 +13,16 @@ const Todo = ({ title, id, whichISelected, displayDetail }) => {
     return collapsedTitle;
   };
 
+  const toggleEdit = () => {
+    setIsEdit((prev) => !prev);
+  };
+
+  const selectTodo = (e) => {
+    whichISelected(e, id);
+  };
+
   return (
-    <div
-      onClick={(e) => {
-        whichISelected(e, id);
-      }}
-      className="flex items-center justify-between h-10 mb-5 group"
-    >
+    <div onClick={selectTodo} className="flex items-center justify-between h-10 mb-5 group">
       <div
         onClick={displayDetail}
         className="flex items-center w-full h-10 ml-5 py-5 border-2 rounded-lg border-emerald-200 active:bg-emerald-100"
@@ -27,10 +32,33 @@ const Todo = ({ title, id, whichISelected, displayDetail }) => {
           {makeCollapsedTitle(20)}
         </p>
       </div>
+      <div className=" flex items-center justify-center ">
+        <CiEdit
+          onClick={toggleEdit}
+          className="duration-150 hover:scale-125 text-green-700 mr-3 "
+          size="30px"
+        />
+        {isEdit && (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-row items-center justify-center bg-zinc-500/70 w-full h-full ">
+            <div>
+              <input
+                placeholder="title"
+                className=" border-2 border-emerald-200 rounded-lg mb-10 h-14 w-3/4"
+              />
+              <input
+                placeholder="detail"
+                className=" border-2 border-emerald-200 rounded-lg h-14 w-3/4"
+              />
+            </div>
+            <button className="bg-zinc-100">닫기</button>
+          </div>
+        )}
 
-      <div className=" flex items-center justify-center invisible group-hover:visible">
-        <CiEdit className="duration-150 hover:scale-125 text-green-700 mr-3 " size="30px" />
-        <CiSquareRemove className="duration-150 mr-5 hover:scale-125 text-red-700" size="30px" />
+        <CiSquareRemove
+          onClick={(e) => deleteTodo(e, id)}
+          className="duration-150 mr-5 hover:scale-125 text-red-700"
+          size="30px"
+        />
       </div>
     </div>
   );

--- a/src/pages/list/TodoModal/TodoModal.jsx
+++ b/src/pages/list/TodoModal/TodoModal.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from "react";
 import { api } from "../../../api/api";
 
-const TodoModal = ({ setIsOpend }) => {
+const TodoModal = ({ setTodoModalIsOpend, setTodoList }) => {
   const [todo, setTodo] = useState({ title: "", content: "" });
   const { title, content } = todo;
 
@@ -24,14 +24,16 @@ const TodoModal = ({ setIsOpend }) => {
       }),
     });
     if (!res.ok) return alert("다시 시도해 주세요");
-
+    const todoData = await res.json();
+    console.log(todoData.data);
     alert("todo가 생성되었습니다");
+    setTodoModalIsOpend((prev) => !prev);
+    setTodoList((prev) => [...prev, todoData.data]);
   };
 
   const submitTodo = (e) => {
     e.preventDefault();
     createTodo();
-    setIsOpend(false);
   };
 
   useEffect(() => {

--- a/src/pages/list/TodoModal/TodoModal.jsx
+++ b/src/pages/list/TodoModal/TodoModal.jsx
@@ -1,0 +1,71 @@
+import React, { useRef, useEffect, useState } from "react";
+import { api } from "../../../api/api";
+
+const TodoModal = ({ setIsOpend }) => {
+  const [todo, setTodo] = useState({ title: "", content: "" });
+  const { title, content } = todo;
+
+  const modalRef = useRef(null);
+
+  const getNewTodo = ({ target: { placeholder, value } }) => {
+    setTodo({ ...todo, [placeholder]: value });
+  };
+
+  const createTodo = async () => {
+    const res = await fetch(api.createTodo, {
+      method: "POST",
+      headers: {
+        "Content-type": "application/json;charset=utf-8",
+        Authorization: localStorage.getItem("todo-token"),
+      },
+      body: JSON.stringify({
+        title: title,
+        content: content,
+      }),
+    });
+    if (!res.ok) return alert("다시 시도해 주세요");
+
+    alert("todo가 생성되었습니다");
+  };
+
+  const submitTodo = (e) => {
+    e.preventDefault();
+    createTodo();
+    setIsOpend(false);
+  };
+
+  useEffect(() => {
+    modalRef.current.focus();
+  }, []);
+  return (
+    <div className="absolute top-1/2 left-1/2 w-3/4  bg-red-50 -translate-x-1/2 -translate-y-1/2 rounded-lg">
+      <form
+        onSubmit={submitTodo}
+        className="flex flex-col items-center justify-center px-3 rounded-lg"
+      >
+        <input
+          onChange={getNewTodo}
+          ref={modalRef}
+          value={title}
+          placeholder="title"
+          className="pl-3 h-8 w-full my-3 rounded-lg"
+        />
+        <input
+          onChange={getNewTodo}
+          value={content}
+          placeholder="content"
+          className="pl-3 h-8 w-full mb-3 rounded-lg"
+        />
+        <button
+          onClick={submitTodo}
+          type="submit"
+          className="w-1/4 mb-3 py-1 bg-emerald-100 rounded-lg "
+        >
+          등록
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default TodoModal;


### PR DESCRIPTION
## 개발한 화면

-

## 개발 내용

- delete 기능추가
- delete 하면 re-render하도록 filter된 list를 setState 하도록 수정
- create 하면 re-render가 안됐는데, create한 객체를 todoList에 추가하는 setState를 구성해서 re-render 되도록 수정
- todo list의 detail을 열어놓고 todo 목록을 지워도 detail이 남아있는 버그가 있어서 todoList.length와 비교해서 사라지도록 수정.

## 회고

- create와 delete때 어떻게 re-render시킬까에 대한 고민이 많았는데, 차근차근 해결.
- delete할때 navigate로 넘기고 params로 받아오면 이전 id가 url에 남아있어서 2번 클릭해야 삭제되는 버그가 있었는데 선택한 element의 id를 받아와서 api로 보내주는 방식으로 수정.
- detail을 열어놓은상태로 목록의 todo를 다 지워도 delete가 그대로 남아있어서 useEffect로 todoList의 length가 0 이면 false되도록 일단 땜질.
- update 용도로 만드는 modal을 portal로 쓸지, absolute로 띄울지 여러 시도해보는중.
- 그러다가 배경색 opacity를 적용하는데서 꽤나 시간을 잡아먹었고, 정말 어이없이 간단하게도 background-color의 rgb`a` 부분의 값을 부여하면 해결되는 문제였음.
