### PR TITLE
Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Todo-list
+[![wakatime](https://wakatime.com/badge/user/e99352fb-fe22-4c5f-8d00-0071140b9a56/project/e47ad9b5-7781-4115-94a2-1fd40f14b856.svg)](https://wakatime.com/badge/user/e99352fb-fe22-4c5f-8d00-0071140b9a56/project/e47ad9b5-7781-4115-94a2-1fd40f14b856)
 
 - 낯익은 todolist이지만, 간단한 C.R.U.D부터 시작해서 늘려나갈 예정입니다.
 

--- a/public/index.html
+++ b/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
   </body>
 </html>

--- a/public/mock/getTodo.json
+++ b/public/mock/getTodo.json
@@ -1,0 +1,18 @@
+{
+  "data": [
+    {
+      "title": "hi1",
+      "content": "hello1",
+      "id": "AGOErdKVVmyUdEBIYo",
+      "createdAt": "2022-07-24T14:15:55.537Z",
+      "updatedAt": "2022-07-24T14:15:55.537Z"
+    },
+    {
+      "title": "hi2",
+      "content": "hello2",
+      "id": "vFeiTUbbyqQacwvt",
+      "createdAt": "2022-07-24T14:15:55.537Z",
+      "updatedAt": "2022-07-24T14:15:55.537Z"
+    }
+  ]
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import List from "./pages/List";
 import Auth from "./pages/Auth";
+import List from "./pages/list/List";
 
 const Router = () => {
   return (

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import Auth from "./pages/Auth";
+
 import List from "./pages/list/List";
+import Auth from "./pages/Auth/Auth";
+import Signin from "./pages/Auth/Signin";
 
 const Router = () => {
   return (
@@ -9,6 +11,7 @@ const Router = () => {
       <Routes>
         <Route path="/" element={<List />} />
         <Route path="/auth" element={<Auth />} />
+        <Route path="/signin" element={<Signin />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,11 @@
+const BASE = "http://localhost:8080";
+
+export const api = {
+  getTodos: `${BASE}/todos`,
+  getTodoById: `${BASE}/todos/:id`,
+  createTodo: `${BASE}/todos`,
+  updateTodo: `${BASE}/todos/:id`,
+  deleteTodo: `${BASE}/todos:id`,
+  signIn: `${BASE}/users/login`,
+  signUp: `${BASE}/users/create`,
+};

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,10 +2,10 @@ const BASE = "http://localhost:8080";
 
 export const api = {
   getTodos: `${BASE}/todos`,
-  getTodoById: `${BASE}/todos/:id`,
+  getTodoById: `${BASE}/todos/`,
   createTodo: `${BASE}/todos`,
-  updateTodo: `${BASE}/todos/:id`,
-  deleteTodo: `${BASE}/todos:id`,
+  updateTodo: `${BASE}/todos/`,
+  deleteTodo: `${BASE}/todos/`,
   signIn: `${BASE}/users/login`,
   signUp: `${BASE}/users/create`,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,4 @@ import Router from "./Router";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(
-  <React.StrictMode>
-    <Router />
-  </React.StrictMode>
-);
+root.render(<Router />);

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const Auth = () => {
-  return <div>Auth</div>;
-};
-
-export default Auth;

--- a/src/pages/Auth/Auth.jsx
+++ b/src/pages/Auth/Auth.jsx
@@ -23,7 +23,7 @@ const Auth = () => {
       body: JSON.stringify(userInfo),
     });
     const createdUser = await response.json();
-    console.log(createdUser.message);
+    alert(createdUser.message);
   };
 
   return (

--- a/src/pages/Auth/Auth.jsx
+++ b/src/pages/Auth/Auth.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+
+const Auth = () => {
+  const [userInfo, setUserInfo] = useState({
+    email: "",
+    password: "",
+  });
+  const { email, password } = userInfo;
+
+  const getUserInfo = (e) => {
+    const { name, value } = e.target;
+    setUserInfo({ ...userInfo, [name]: value });
+  };
+
+  const validation = email.includes("@") && password.length >= 8;
+
+  const signUp = async () => {
+    const response = await fetch("http://localhost:8080/users/create", {
+      method: "POST",
+      headers: { "Content-type": "application/json;charset=utf-8" },
+      body: JSON.stringify(userInfo),
+    });
+    const createdUser = await response.json();
+    console.log(createdUser.message);
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center max-w-md p-10 border-2 border-emerald-300">
+      <h1 className="mb-5 text-md">회원가입</h1>
+
+      <form className="flex flex-col">
+        <input
+          placeholder="ID"
+          type="email"
+          value={email}
+          name="email"
+          onChange={getUserInfo}
+          className={`p-3 px-4 border-2 w-[300px] ${
+            email.includes("@") && "border-emerald-200"
+          } rounded-md mb-5 focus:outline-none `}
+        />
+        <input
+          placeholder="PASSWORD"
+          type="password"
+          value={password}
+          name="password"
+          onChange={getUserInfo}
+          className={`py-3 px-4 border-2 w-[300px] ${
+            password.length >= 8 && "border-emerald-200"
+          } rounded-md mb-5 focus:outline-none`}
+        />
+        <button
+          className="disabled:bg-red-100 enabled:bg-emerald-100 enabled:active:bg-emerald-300 rounded-md "
+          type="button"
+          disabled={!validation}
+          onClick={signUp}
+        >
+          회원가입
+        </button>
+      </form>
+      <p className="mt-10">
+        회원가입 했다면?{" "}
+        <Link className="border-b-2 border-b-emerald-200 px-2 py-1 " to="/signin">
+          로그인하러 가기
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/pages/Auth/Auth.jsx
+++ b/src/pages/Auth/Auth.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
+import { api } from "../../api/api";
 
 const Auth = () => {
   const [userInfo, setUserInfo] = useState({
@@ -16,7 +17,7 @@ const Auth = () => {
   const validation = email.includes("@") && password.length >= 8;
 
   const signUp = async () => {
-    const response = await fetch("http://localhost:8080/users/create", {
+    const response = await fetch(api.signUp, {
       method: "POST",
       headers: { "Content-type": "application/json;charset=utf-8" },
       body: JSON.stringify(userInfo),
@@ -26,7 +27,7 @@ const Auth = () => {
   };
 
   return (
-    <div className="flex flex-col justify-center items-center max-w-md p-10 border-2 border-emerald-300">
+    <div className="flex flex-col justify-center items-center h-screen max-w-md p-10 border-none">
       <h1 className="mb-5 text-md">회원가입</h1>
 
       <form className="flex flex-col">

--- a/src/pages/Auth/Signin.jsx
+++ b/src/pages/Auth/Signin.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+
+const Signin = () => {
+  const [userInfo, setUserInfo] = useState({
+    email: "",
+    password: "",
+  });
+  const { email, password } = userInfo;
+  const navigate = useNavigate();
+
+  const getUserInfo = (e) => {
+    const { name, value } = e.target;
+    setUserInfo({ ...userInfo, [name]: value });
+  };
+
+  const validation = email.includes("@") && password.length >= 8;
+
+  const signUp = async (e) => {
+    e.preventDefault();
+    const response = await fetch("http://localhost:8080/users/login", {
+      method: "POST",
+      headers: { "Content-type": "application/json;charset=utf-8" },
+      body: JSON.stringify(userInfo),
+    });
+    const createdUser = await response.json();
+    if (!createdUser.token) {
+      alert("로그인 정보를 다시 확인 해 보세요");
+      navigate("/signin");
+    } else {
+      alert("로그인 성공");
+      localStorage.setItem("todo-token", createdUser.token);
+      setUserInfo({ ...userInfo, email: "", password: "" });
+      navigate("/");
+    }
+  };
+  return (
+    <div className="flex flex-col justify-center items-center max-w-md p-10 border-2 border-emerald-300">
+      <h1 className="mb-5 text-md">로그인</h1>
+
+      <form className="flex flex-col" onSubmit={signUp}>
+        <input
+          placeholder="ID"
+          type="email"
+          value={email}
+          name="email"
+          onChange={getUserInfo}
+          className={`p-3 px-4 border-2 w-[300px] ${
+            email.includes("@") && "border-emerald-200"
+          } rounded-md mb-5 focus:outline-none `}
+        />
+        <input
+          placeholder="PASSWORD"
+          type="password"
+          value={password}
+          name="password"
+          onChange={getUserInfo}
+          className={`py-3 px-4 border-2 w-[300px] ${
+            password.length >= 8 && "border-emerald-200"
+          } rounded-md mb-5 focus:outline-none`}
+        />
+        <button
+          className="disabled:bg-red-100 enabled:bg-emerald-100 enabled:active:bg-emerald-300 rounded-md "
+          type="submit"
+          disabled={!validation}
+          onClick={signUp}
+        >
+          로그인
+        </button>
+      </form>
+      <p className="mt-10">
+        아직 가입하지않았다면
+        <Link className="border-b-2 border-b-emerald-200 px-2 py-1 " to="/auth">
+          회원가입하러 가기
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default Signin;

--- a/src/pages/Auth/Signin.jsx
+++ b/src/pages/Auth/Signin.jsx
@@ -34,8 +34,18 @@ const Signin = () => {
       navigate("/");
     }
   };
+
+  const goToList = () => {
+    navigate("/");
+  };
   return (
-    <div className="flex flex-col justify-center items-center max-w-md p-10 border-2 border-emerald-300">
+    <div className="flex flex-col justify-center items-center h-screen max-w-md p-10">
+      <div className="w-full text-right">
+        <button onClick={goToList} className="mr-5 mb-3 px-5 py-1 bg-zinc-300 rounded-lg">
+          todoList
+        </button>
+      </div>
+
       <h1 className="mb-5 text-md">로그인</h1>
 
       <form className="flex flex-col" onSubmit={signUp}>

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const List = () => {
-  return <div>List</div>;
-};
-
-export default List;

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -5,8 +5,8 @@ import { api } from "../../api/api";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
+  const [isSelected, setIsSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
-  const [isTodoChecked, setIsTodoChecked] = useState(false);
 
   const navigate = useNavigate();
 
@@ -20,13 +20,16 @@ const List = () => {
     navigate("signin");
   };
 
+  const displayDetail = () => {
+    setIsSelected(true);
+  };
+  const hiddenDetail = () => {
+    setIsSelected(false);
+  };
+
   const whichISelected = (e, selectedId) => {
     const selectedTodo = todoList.find(({ id }) => id === selectedId);
     setSelectedTodo(selectedTodo);
-  };
-
-  const selectOrNot = (e) => {
-    setIsTodoChecked(e.target.checked);
   };
 
   useEffect(() => {
@@ -51,7 +54,6 @@ const List = () => {
     //   },
     // });
   }, []);
-
   return (
     <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
@@ -65,17 +67,29 @@ const List = () => {
           +
         </button>
       </div>
-      {todoList.map(({ id, title }) => (
-        <Todo
-          key={id}
-          title={title}
-          id={id}
-          text={"Bernard Shelton"}
-          whichISelected={whichISelected}
-          selectOrNot={selectOrNot}
-        />
-      ))}
-      {isTodoChecked && <div className="bg-emerald-100 mx-5">{selectedTodo.content}</div>}
+      {todoList &&
+        todoList.map(({ id, title }) => (
+          <Todo
+            key={id}
+            title={title}
+            id={id}
+            whichISelected={whichISelected}
+            displayDetail={displayDetail}
+          />
+        ))}
+      {isSelected && (
+        <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
+          <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
+            {selectedTodo.content}
+          </p>
+          <button
+            onClick={hiddenDetail}
+            className="w-1/6 h-10 ml-5 bg-zinc-100  active:bg-zinc-300 active:text-white rounded-lg text-sm"
+          >
+            닫기
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+import Todo from "./Todo";
+
+const List = () => {
+  const [todoList, setTodoList] = useState([]);
+
+  const getTodo = async (url) => {
+    const response = await fetch(url);
+    const todoData = await response.json();
+    setTodoList(todoData.data);
+  };
+
+  useEffect(() => {
+    getTodo("/mock/getTodo.json");
+  }, []);
+
+  return (
+    <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
+      <div className="w-full text-right p-4">
+        <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 mr-3 active:bg-zinc-300 active:text-white">
+          Login
+        </button>
+        <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white">
+          +
+        </button>
+      </div>
+      {todoList.map(({ id, content, title }) => (
+        <Todo key={id} content={content} title={title} labelId={id} text={"Bernard Shelton"} />
+      ))}
+    </div>
+  );
+};
+
+export default List;

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Todo from "./Todo";
 import { api } from "../../api/api";
+import TodoModal from "./TodoModal/TodoModal";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
   const [isSelected, setIsSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
+  const [isOpend, setIsOpend] = useState(false);
 
   const navigate = useNavigate();
 
@@ -32,6 +34,10 @@ const List = () => {
     setSelectedTodo(selectedTodo);
   };
 
+  const toggleTodoModal = () => {
+    setIsOpend((prev) => !prev);
+  };
+
   useEffect(() => {
     if (!localStorage.getItem("todo-token")) {
       alert("로그인이 필요합니다");
@@ -44,18 +50,9 @@ const List = () => {
         Authorization: localStorage.getItem("todo-token"),
       },
     });
-    getTodo("/mock/getTodo.json");
-    //TODO: createTodo 만들어지면 사용 예정
-    // getTodo(api.getTodos, {
-    //   method: "GET",
-    //   headers: {
-    //     "Content-type": "application/json;charset=utf-8",
-    //     Authorization: localStorage.getItem("todo-token"),
-    //   },
-    // });
-  }, []);
+  }, [todoList]);
   return (
-    <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
+    <div className="relative m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
         <button
           onClick={goToSignIn}
@@ -63,10 +60,14 @@ const List = () => {
         >
           Login
         </button>
-        <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white">
+        <button
+          onClick={toggleTodoModal}
+          className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white"
+        >
           +
         </button>
       </div>
+      {isOpend && <TodoModal setIsOpend={setIsOpend} />}
       {todoList &&
         todoList.map(({ id, title }) => (
           <Todo
@@ -80,7 +81,7 @@ const List = () => {
       {isSelected && (
         <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
           <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
-            {selectedTodo.content}
+            {selectedTodo.content || "todoDetail입니다"}
           </p>
           <button
             onClick={hiddenDetail}

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -1,23 +1,43 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Todo from "./Todo";
+import { api } from "../../api/api";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
+  const navigate = useNavigate();
 
-  const getTodo = async (url) => {
-    const response = await fetch(url);
+  const getTodo = async (url, option) => {
+    const response = await fetch(url, option);
     const todoData = await response.json();
     setTodoList(todoData.data);
   };
 
+  const goToSignIn = () => {
+    navigate("signin");
+  };
+
   useEffect(() => {
-    getTodo("/mock/getTodo.json");
+    if (!localStorage.getItem("todo-token")) {
+      alert("로그인이 필요합니다");
+      navigate("/signin");
+    }
+    getTodo(api.getTodos, {
+      method: "GET",
+      headers: {
+        "Content-type": "application/json;charset=utf-8",
+        Authorization: localStorage.getItem("todo-token"),
+      },
+    });
   }, []);
 
   return (
     <div className="m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
-        <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 mr-3 active:bg-zinc-300 active:text-white">
+        <button
+          onClick={goToSignIn}
+          className="text-md bg-zinc-100 rounded-lg px-3 py-1 mr-3 active:bg-zinc-300 active:text-white"
+        >
           Login
         </button>
         <button className="text-md bg-zinc-100 rounded-lg px-3 py-1 active:bg-zinc-300 active:text-white">

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -6,10 +6,9 @@ import TodoModal from "./TodoModal/TodoModal";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
-  const [isSelected, setIsSelected] = useState(false);
+  const [isTodoSelected, setIsTodoSelected] = useState(false);
   const [selectedTodo, setSelectedTodo] = useState({});
-  const [isOpend, setIsOpend] = useState(false);
-
+  const [isTodoModalOpend, setTodoModalIsOpend] = useState(false);
   const navigate = useNavigate();
 
   const getTodo = async (url, option) => {
@@ -23,10 +22,10 @@ const List = () => {
   };
 
   const displayDetail = () => {
-    setIsSelected(true);
+    setIsTodoSelected(true);
   };
   const hiddenDetail = () => {
-    setIsSelected(false);
+    setIsTodoSelected(false);
   };
 
   const whichISelected = (e, selectedId) => {
@@ -35,7 +34,21 @@ const List = () => {
   };
 
   const toggleTodoModal = () => {
-    setIsOpend((prev) => !prev);
+    setTodoModalIsOpend((prev) => !prev);
+  };
+
+  const deleteTodo = async (e, selectedId) => {
+    const response = await fetch(`${api.deleteTodo}${selectedId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-type": "application/json",
+        Authorization: localStorage.getItem("todo-token"),
+      },
+    });
+    if (response.ok) {
+      const filteredList = todoList.filter((list) => list.id !== selectedId);
+      setTodoList(filteredList);
+    }
   };
 
   useEffect(() => {
@@ -50,7 +63,12 @@ const List = () => {
         Authorization: localStorage.getItem("todo-token"),
       },
     });
+  }, []);
+
+  useEffect(() => {
+    if (todoList.length === 0) setIsTodoSelected(false);
   }, [todoList]);
+
   return (
     <div className="relative m-10 max-w-2xl border-2 rounded-lg pb-10">
       <div className="w-full text-right p-4">
@@ -67,7 +85,9 @@ const List = () => {
           +
         </button>
       </div>
-      {isOpend && <TodoModal setIsOpend={setIsOpend} />}
+      {isTodoModalOpend && (
+        <TodoModal setTodoModalIsOpend={setTodoModalIsOpend} setTodoList={setTodoList} />
+      )}
       {todoList &&
         todoList.map(({ id, title }) => (
           <Todo
@@ -76,9 +96,10 @@ const List = () => {
             id={id}
             whichISelected={whichISelected}
             displayDetail={displayDetail}
+            deleteTodo={deleteTodo}
           />
         ))}
-      {isSelected && (
+      {isTodoSelected && (
         <div className="flex items-start justify-between rounded-lg p-3 bg-emerald-50 mx-5">
           <p className="w-full p-3 border-2 rounded-lg text-sm break-words">
             {selectedTodo.content || "todoDetail입니다"}

--- a/src/pages/list/List.jsx
+++ b/src/pages/list/List.jsx
@@ -5,6 +5,9 @@ import { api } from "../../api/api";
 
 const List = () => {
   const [todoList, setTodoList] = useState([]);
+  const [selectedTodo, setSelectedTodo] = useState({});
+  const [isTodoChecked, setIsTodoChecked] = useState(false);
+
   const navigate = useNavigate();
 
   const getTodo = async (url, option) => {
@@ -15,6 +18,15 @@ const List = () => {
 
   const goToSignIn = () => {
     navigate("signin");
+  };
+
+  const whichISelected = (e, selectedId) => {
+    const selectedTodo = todoList.find(({ id }) => id === selectedId);
+    setSelectedTodo(selectedTodo);
+  };
+
+  const selectOrNot = (e) => {
+    setIsTodoChecked(e.target.checked);
   };
 
   useEffect(() => {
@@ -29,6 +41,15 @@ const List = () => {
         Authorization: localStorage.getItem("todo-token"),
       },
     });
+    getTodo("/mock/getTodo.json");
+    //TODO: createTodo 만들어지면 사용 예정
+    // getTodo(api.getTodos, {
+    //   method: "GET",
+    //   headers: {
+    //     "Content-type": "application/json;charset=utf-8",
+    //     Authorization: localStorage.getItem("todo-token"),
+    //   },
+    // });
   }, []);
 
   return (
@@ -44,9 +65,17 @@ const List = () => {
           +
         </button>
       </div>
-      {todoList.map(({ id, content, title }) => (
-        <Todo key={id} content={content} title={title} labelId={id} text={"Bernard Shelton"} />
+      {todoList.map(({ id, title }) => (
+        <Todo
+          key={id}
+          title={title}
+          id={id}
+          text={"Bernard Shelton"}
+          whichISelected={whichISelected}
+          selectOrNot={selectOrNot}
+        />
       ))}
+      {isTodoChecked && <div className="bg-emerald-100 mx-5">{selectedTodo.content}</div>}
     </div>
   );
 };

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,22 +1,33 @@
 import React from "react";
 import { CiEdit, CiSquareRemove } from "react-icons/ci";
 
-const Todo = ({ title, id, whichISelected, selectOrNot }) => {
+const Todo = ({ title, id, whichISelected, displayDetail }) => {
+  const makeCollapsedTitle = (index) => {
+    if (title.length < index) return title;
+
+    const startIndex = title.substring(0, index);
+    const concatedString = "...";
+    const collapsedTitle = startIndex + concatedString;
+    return collapsedTitle;
+  };
+
   return (
     <div
       onClick={(e) => {
         whichISelected(e, id);
       }}
-      className="flex items-center justify-center h-10 mb-5 group"
+      className="flex items-center justify-between h-10 mb-5 group"
     >
-      <label htmlFor={id} className="w-full h-10 ml-5">
-        <div className="flex items-center h-10 py-5 border-2 border-emerald-200 duration-150 active:scale-105 ">
-          <input id={id} type="checkbox" className="mx-5" onChange={selectOrNot} />
-          <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
-            {title}
-          </p>
-        </div>
-      </label>
+      <div
+        onClick={displayDetail}
+        className="flex items-center w-full h-10 ml-5 py-5 border-2 rounded-lg border-emerald-200 active:bg-emerald-100"
+      >
+        <input type="checkbox" className="mx-5" />
+        <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
+          {makeCollapsedTitle(20)}
+        </p>
+      </div>
+
       <div className=" flex items-center justify-center invisible group-hover:visible">
         <CiEdit className="duration-150 hover:scale-125 text-green-700 mr-3 " size="30px" />
         <CiSquareRemove className="duration-150 mr-5 hover:scale-125 text-red-700" size="30px" />

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { CiEdit, CiSquareRemove } from "react-icons/ci";
+
+const Todo = ({ title, content, labelId }) => {
+  return (
+    <div className="flex items-center justify-center h-10 mb-5  group">
+      <label htmlFor={labelId} className="w-full h-10 ml-5">
+        <div className="flex items-center h-10 py-5 border-2 border-emerald-200 duration-150 active:scale-105 ">
+          <input id={labelId} type="checkbox" className="mx-5" />
+          <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
+            {content}
+          </p>
+        </div>
+      </label>
+      <div className=" flex items-center justify-center invisible group-hover:visible">
+        <CiEdit className="duration-150 hover:scale-125 text-green-700 mr-3 " size="30px" />
+        <CiSquareRemove className="duration-150 mr-5 hover:scale-125 text-red-700" size="30px" />
+      </div>
+    </div>
+  );
+};
+
+export default Todo;

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { CiEdit, CiSquareRemove } from "react-icons/ci";
 
-const Todo = ({ title, content, labelId }) => {
+const Todo = ({ title, id, whichISelected, selectOrNot }) => {
   return (
-    <div className="flex items-center justify-center h-10 mb-5  group">
-      <label htmlFor={labelId} className="w-full h-10 ml-5">
+    <div
+      onClick={(e) => {
+        whichISelected(e, id);
+      }}
+      className="flex items-center justify-center h-10 mb-5 group"
+    >
+      <label htmlFor={id} className="w-full h-10 ml-5">
         <div className="flex items-center h-10 py-5 border-2 border-emerald-200 duration-150 active:scale-105 ">
-          <input id={labelId} type="checkbox" className="mx-5" />
+          <input id={id} type="checkbox" className="mx-5" onChange={selectOrNot} />
           <p type="text" className=" focus:outline-none duration-150 focus:scale-110">
-            {content}
+            {title}
           </p>
         </div>
       </label>

--- a/src/pages/list/Todo.jsx
+++ b/src/pages/list/Todo.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { CiEdit, CiSquareRemove } from "react-icons/ci";
 
-const Todo = ({ title, id, whichISelected, displayDetail }) => {
+const Todo = ({ title, id, whichISelected, displayDetail, deleteTodo }) => {
+  const [isEdit, setIsEdit] = useState(false);
+
   const makeCollapsedTitle = (index) => {
     if (title.length < index) return title;
 
@@ -11,13 +13,16 @@ const Todo = ({ title, id, whichISelected, displayDetail }) => {
     return collapsedTitle;
   };
 
+  const toggleEdit = () => {
+    setIsEdit((prev) => !prev);
+  };
+
+  const selectTodo = (e) => {
+    whichISelected(e, id);
+  };
+
   return (
-    <div
-      onClick={(e) => {
-        whichISelected(e, id);
-      }}
-      className="flex items-center justify-between h-10 mb-5 group"
-    >
+    <div onClick={selectTodo} className="flex items-center justify-between h-10 mb-5 group">
       <div
         onClick={displayDetail}
         className="flex items-center w-full h-10 ml-5 py-5 border-2 rounded-lg border-emerald-200 active:bg-emerald-100"
@@ -27,10 +32,33 @@ const Todo = ({ title, id, whichISelected, displayDetail }) => {
           {makeCollapsedTitle(20)}
         </p>
       </div>
+      <div className=" flex items-center justify-center ">
+        <CiEdit
+          onClick={toggleEdit}
+          className="duration-150 hover:scale-125 text-green-700 mr-3 "
+          size="30px"
+        />
+        {isEdit && (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-row items-center justify-center bg-zinc-500/70 w-full h-full ">
+            <div>
+              <input
+                placeholder="title"
+                className=" border-2 border-emerald-200 rounded-lg mb-10 h-14 w-3/4"
+              />
+              <input
+                placeholder="detail"
+                className=" border-2 border-emerald-200 rounded-lg h-14 w-3/4"
+              />
+            </div>
+            <button className="bg-zinc-100">닫기</button>
+          </div>
+        )}
 
-      <div className=" flex items-center justify-center invisible group-hover:visible">
-        <CiEdit className="duration-150 hover:scale-125 text-green-700 mr-3 " size="30px" />
-        <CiSquareRemove className="duration-150 mr-5 hover:scale-125 text-red-700" size="30px" />
+        <CiSquareRemove
+          onClick={(e) => deleteTodo(e, id)}
+          className="duration-150 mr-5 hover:scale-125 text-red-700"
+          size="30px"
+        />
       </div>
     </div>
   );

--- a/src/pages/list/TodoModal/TodoModal.jsx
+++ b/src/pages/list/TodoModal/TodoModal.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from "react";
 import { api } from "../../../api/api";
 
-const TodoModal = ({ setIsOpend }) => {
+const TodoModal = ({ setTodoModalIsOpend, setTodoList }) => {
   const [todo, setTodo] = useState({ title: "", content: "" });
   const { title, content } = todo;
 
@@ -24,14 +24,16 @@ const TodoModal = ({ setIsOpend }) => {
       }),
     });
     if (!res.ok) return alert("다시 시도해 주세요");
-
+    const todoData = await res.json();
+    console.log(todoData.data);
     alert("todo가 생성되었습니다");
+    setTodoModalIsOpend((prev) => !prev);
+    setTodoList((prev) => [...prev, todoData.data]);
   };
 
   const submitTodo = (e) => {
     e.preventDefault();
     createTodo();
-    setIsOpend(false);
   };
 
   useEffect(() => {

--- a/src/pages/list/TodoModal/TodoModal.jsx
+++ b/src/pages/list/TodoModal/TodoModal.jsx
@@ -1,0 +1,71 @@
+import React, { useRef, useEffect, useState } from "react";
+import { api } from "../../../api/api";
+
+const TodoModal = ({ setIsOpend }) => {
+  const [todo, setTodo] = useState({ title: "", content: "" });
+  const { title, content } = todo;
+
+  const modalRef = useRef(null);
+
+  const getNewTodo = ({ target: { placeholder, value } }) => {
+    setTodo({ ...todo, [placeholder]: value });
+  };
+
+  const createTodo = async () => {
+    const res = await fetch(api.createTodo, {
+      method: "POST",
+      headers: {
+        "Content-type": "application/json;charset=utf-8",
+        Authorization: localStorage.getItem("todo-token"),
+      },
+      body: JSON.stringify({
+        title: title,
+        content: content,
+      }),
+    });
+    if (!res.ok) return alert("다시 시도해 주세요");
+
+    alert("todo가 생성되었습니다");
+  };
+
+  const submitTodo = (e) => {
+    e.preventDefault();
+    createTodo();
+    setIsOpend(false);
+  };
+
+  useEffect(() => {
+    modalRef.current.focus();
+  }, []);
+  return (
+    <div className="absolute top-1/2 left-1/2 w-3/4  bg-red-50 -translate-x-1/2 -translate-y-1/2 rounded-lg">
+      <form
+        onSubmit={submitTodo}
+        className="flex flex-col items-center justify-center px-3 rounded-lg"
+      >
+        <input
+          onChange={getNewTodo}
+          ref={modalRef}
+          value={title}
+          placeholder="title"
+          className="pl-3 h-8 w-full my-3 rounded-lg"
+        />
+        <input
+          onChange={getNewTodo}
+          value={content}
+          placeholder="content"
+          className="pl-3 h-8 w-full mb-3 rounded-lg"
+        />
+        <button
+          onClick={submitTodo}
+          type="submit"
+          className="w-1/4 mb-3 py-1 bg-emerald-100 rounded-lg "
+        >
+          등록
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default TodoModal;


### PR DESCRIPTION
## 개발한 화면

- todo 추가

https://user-images.githubusercontent.com/79638133/233228378-0a522d49-2917-44b4-9f5a-bc324cd36c3a.mov

-todo Detail 출력

https://user-images.githubusercontent.com/79638133/233228455-b68bdc8f-f3aa-4910-bd07-976a02530d93.mov

-todo 삭제

https://user-images.githubusercontent.com/79638133/233228569-2437b93c-8ea3-44cd-977e-c4c3b5968e37.mov

-회원가입

https://user-images.githubusercontent.com/79638133/233232528-20a17259-3b2d-4fe3-a9d0-73282d440124.mov

-로그인

https://user-images.githubusercontent.com/79638133/233232773-cb20fa81-b541-4500-b0d3-200f39282096.mov








## 개발 내용
####  [48fdafe](https://github.com/201steve/todo/pull/8/commits/48fdafe4f05839682faa40867c3ac4c35bcaea37)
- layout signup, signin
- add login validate
- 토큰 여부에 따른 route 처리 추가
#### [3095ef7](https://github.com/201steve/todo/pull/8/commits/3095ef7e8461c26be34b27ab35e3b9dd54844b49)
- api주소 관리용 파일 추가
- 토큰 유효하지않다면 로그인페이지로 리다이렉트 추가
#### [d5baa95](https://github.com/201steve/todo/pull/8/commits/d5baa9549fc9af43d99677a2cb6e3a196a70c0b6)
- 특정 todo를 선택하면, 상세내역 출력
#### [5216eca](https://github.com/201steve/todo/pull/8/commits/5216eca39996e3ff7ef41165ad8d1599cf379a26)
- label태그 삭제
- 체크박스에 체크 되야 detail이 보이던 방식에서 todo 클릭 하면 보이는것으로 수정
- detail 닫기 버튼 추가
- title의길이가 특정 index이상 되면 ... 으로 collapse되게 view 수정
- input scale transition 삭제
#### [34eecbf](https://github.com/201steve/todo/pull/8/commits/34eecbf49b4ba5d9c6cbb08681dcf4fde868a9ce)
- create todo 기능 추가
#### [5229454](https://github.com/201steve/todo/pull/8/commits/52294540ecbd2d5b1ee2bb2cafa2e1e6e6e0f0f0)
- delete 버튼을 누르면 todo 삭제 되는 기능 추가
- delete 버튼을 누르고 삭제되면 re-render되도록 setState 구성
- createTodo 하면re-render 되도록 setState수정
- update 용도 modal 구현중




## Assignment 1 - Login / SignUp

- /auth 경로에 로그인 / 회원가입 기능을 개발합니다
  - 로그인, 회원가입을 별도의 경로로 분리해도 무방합니다
  - [x] 최소한 이메일, 비밀번호 input, 제출 button을 갖도록 구성해주세요
- 이메일과 비밀번호의 유효성을 확인합니다
  - [x] 이메일 조건 : 최소 `@`, `.` 포함
  - [x] 비밀번호 조건 : 8자 이상 입력
  - [x] 이메일과 비밀번호가 모두 입력되어 있고, 조건을 만족해야 제출 버튼이 활성화 되도록 해주세요
- 로그인 API를 호출하고, 올바른 응답을 받았을 때 루트 경로로 이동시켜주세요
  - [x] 응답으로 받은 토큰은 로컬 스토리지에 저장해주세요
  - [x] 다음 번에 로그인 시 토큰이 존재한다면 루트 경로로 리다이렉트 시켜주세요
  - [x] 어떤 경우든 토큰이 유효하지 않다면 사용자에게 알리고 로그인 페이지로 리다이렉트 시켜주세요

## Assignment 2 - Todo List

- Todo List API를 호출하여 Todo List CRUD 기능을 구현해주세요
  - [x] 목록 / 상세 영역으로 나누어 구현해주세요
  - [x] Todo 목록을 볼 수 있습니다.
  - [x] Todo 추가 버튼을 클릭하면 할 일이 추가 됩니다.
  - [ ] Todo 수정 버튼을 클릭하면 수정 모드를 활성화하고, 수정 내용을 제출하거나 취소할 수 있습니다.
  - [x] Todo 삭제 버튼을 클릭하면 해당 Todo를 삭제할 수 있습니다.
- 한 화면 내에서 Todo List와 개별 Todo의 상세를 확인할 수 있도록 해주세요.
  - [ ] 새로고침을 했을 때 현재 상태가 유지되어야 합니다.
  - [ ] 개별 Todo를 조회 순서에 따라 페이지 뒤로가기를 통하여 조회할 수 있도록 해주세요.
- 한 페이지 내에서 새로고침 없이 데이터가 정합성을 갖추도록 구현해주세요

  - [ ] 수정되는 Todo의 내용이 목록에서도 실시간으로 반영되어야 합니다
## 회고

- create와 delete때 어떻게 re-render시킬까에 대한 고민이 많았는데, 차근차근 해결.
- delete할때 navigate로 넘기고 params로 받아오면 이전 id가 url에 남아있어서 2번 클릭해야 삭제되는 버그가 있었는데 선택한 element의 id를 받아와서 api로 보내주는 방식으로 수정.
- detail을 열어놓은상태로 목록의 todo를 다 지워도 delete가 그대로 남아있어서 useEffect로 todoList의 length가 0 이면 false되도록 일단 땜질.
- update 용도로 만드는 modal을 portal로 쓸지, absolute로 띄울지 여러 시도해보는중.
- 그러다가 배경색 opacity를 적용하는데서 꽤나 시간을 잡아먹었고, 정말 어이없이 간단하게도 background-color의 rgba 부분의 값을 부여하면 해결되는 문제였음.
